### PR TITLE
CMake build file for muparserx project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,7 @@
 # Project setup
 ########################################################################
 cmake_minimum_required(VERSION 2.8.0)
-project(muparserx)
-enable_language(CXX)
-enable_testing()
+project(muparserx CXX)
 
 ########################################################################
 # Extract version
@@ -32,10 +30,11 @@ endif()
 
 ########################################################################
 # Build library
+# Defaults to static, set BUILD_SHARED_LIBS=ON for shared
 ########################################################################
 file(GLOB MUPARSERX_SOURCES "${MUPARSERX_SOURCE_DIR}/*.cpp")
 include_directories(${MUPARSERX_SOURCE_DIR})
-add_library(muparserx STATIC ${MUPARSERX_SOURCES})
+add_library(muparserx ${MUPARSERX_SOURCES})
 set_target_properties(muparserx PROPERTIES VERSION ${MUPARSERX_VERSION})
 
 #link with lib math when found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+########################################################################
+# Project setup
+########################################################################
+cmake_minimum_required(VERSION 2.8.0)
+project(muparserx)
+enable_language(CXX)
+enable_testing()
+
+########################################################################
+# Extract version
+########################################################################
+set(MUPARSERX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/parser)
+file(READ "${MUPARSERX_SOURCE_DIR}/mpDefines.h" mpDefines_h)
+string(REGEX MATCH "\\#define MUP_PARSER_VERSION _T\\(\"([0-9]+\\.[0-9]+\\.[0-9]+) \\(" MUPARSERX_VERSION_MATCHES "${mpDefines_h}")
+if (NOT MUPARSERX_VERSION_MATCHES)
+    message(FATAL_ERROR "Failed to extract version number from mpDefines.h")
+endif ()
+set(MUPARSERX_VERSION ${CMAKE_MATCH_1})
+
+########################################################################
+# Compiler specific flags
+########################################################################
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-pedantic)
+    add_compile_options(-Wall)
+    add_compile_options(-Wextra)
+endif()
+
+if(MSVC)
+    add_compile_options(/MP) #multi-core build
+endif()
+
+########################################################################
+# Build library
+########################################################################
+file(GLOB MUPARSERX_SOURCES "${MUPARSERX_SOURCE_DIR}/*.cpp")
+include_directories(${MUPARSERX_SOURCE_DIR})
+add_library(muparserx STATIC ${MUPARSERX_SOURCES})
+set_target_properties(muparserx PROPERTIES VERSION ${MUPARSERX_VERSION})
+
+#link with lib math when found
+find_library(
+    M_LIBRARY NAMES m
+    PATHS /usr/lib /usr/lib64
+)
+if (M_LIBRARY)
+    target_link_libraries(muparserx ${M_LIBRARY})
+endif()
+
+install(TARGETS muparserx
+    LIBRARY DESTINATION lib${LIB_SUFFIX} # .so file
+    ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
+    RUNTIME DESTINATION bin              # .dll file
+)
+
+########################################################################
+# Build pkg config file
+########################################################################
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/muparserx.in.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/muparserx.pc
+@ONLY)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/muparserx.pc
+    DESTINATION lib${LIB_SUFFIX}/pkgconfig
+)
+
+########################################################################
+# Install headers
+########################################################################
+file(GLOB MUPARSERX_HEADERS "${MUPARSERX_SOURCE_DIR}/*.h")
+install(
+    FILES ${MUPARSERX_HEADERS}
+    DESTINATION include
+)
+
+########################################################################
+# Example application
+########################################################################
+add_executable(example sample/example.cpp sample/timer.cpp)
+target_link_libraries(example muparserx)
+
+########################################################################
+# Print summary
+########################################################################
+message(STATUS "Building muparserx version: ${MUPARSERX_VERSION}")
+message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,11 @@ install(
 ########################################################################
 # Example application
 ########################################################################
-add_executable(example sample/example.cpp sample/timer.cpp)
-target_link_libraries(example muparserx)
+option(BUILD_EXAMPLES "enable building example applications" ON)
+if (BUILD_EXAMPLES)
+    add_executable(example sample/example.cpp sample/timer.cpp)
+    target_link_libraries(example muparserx)
+endif ()
 
 ########################################################################
 # Print summary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ project(muparserx CXX)
 set(MUPARSERX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/parser)
 file(READ "${MUPARSERX_SOURCE_DIR}/mpDefines.h" mpDefines_h)
 string(REGEX MATCH "\\#define MUP_PARSER_VERSION _T\\(\"([0-9]+\\.[0-9]+\\.[0-9]+) \\(" MUPARSERX_VERSION_MATCHES "${mpDefines_h}")
-if (NOT MUPARSERX_VERSION_MATCHES)
+if(NOT MUPARSERX_VERSION_MATCHES)
     message(FATAL_ERROR "Failed to extract version number from mpDefines.h")
-endif ()
+endif(NOT MUPARSERX_VERSION_MATCHES)
 set(MUPARSERX_VERSION ${CMAKE_MATCH_1})
 
 ########################################################################
@@ -22,11 +22,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(-pedantic)
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
-endif()
+endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(MSVC)
     add_compile_options(/MP) #multi-core build
-endif()
+endif(MSVC)
 
 ########################################################################
 # Build library
@@ -42,9 +42,9 @@ find_library(
     M_LIBRARY NAMES m
     PATHS /usr/lib /usr/lib64
 )
-if (M_LIBRARY)
+if(M_LIBRARY)
     target_link_libraries(muparserx ${M_LIBRARY})
-endif()
+endif(M_LIBRARY)
 
 install(TARGETS muparserx
     LIBRARY DESTINATION lib${LIB_SUFFIX} # .so file
@@ -78,10 +78,10 @@ install(
 # Example application
 ########################################################################
 option(BUILD_EXAMPLES "enable building example applications" ON)
-if (BUILD_EXAMPLES)
+if(BUILD_EXAMPLES)
     add_executable(example sample/example.cpp sample/timer.cpp)
     target_link_libraries(example muparserx)
-endif ()
+endif(BUILD_EXAMPLES)
 
 ########################################################################
 # Print summary

--- a/muparserx.in.pc
+++ b/muparserx.in.pc
@@ -1,0 +1,15 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib@LIB_SUFFIX@
+includedir=${prefix}/include
+
+Name: muparserx
+Description: A mathematical expression parser library.
+URL: http://articles.beltoforion.de/article.php?a=muparserx
+Version: @MUPARSERX_VERSION@
+Requires:
+Requires.private:
+Conflicts:
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmuparserx
+Libs.private:


### PR DESCRIPTION
Referencing https://github.com/beltoforion/muparserx/issues/49 A CMake build system could replace several other build systems and aid in packaging. Ive tested this on ubuntu w/ gcc and windows with msvc.