### PR TITLE
Add missing c++11 to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #CFLAGS	=	-O3 -Wall -pedantic -ffast-math -fomit-frame-pointer 
 
 CC      = clang++
-CFLAGS	=	`llvm-config --ldflags` -O3 -Wall -pedantic
+CFLAGS	=	`llvm-config --ldflags` -O3 -Wall -pedantic -std=c++11
 
 # debug version
 #CFLAGS  = -Wall -ggdb  


### PR DESCRIPTION
I get a lot of compilation errors like
```
In file included from parser/mpError.cpp:36:
In file included from parser/mpIToken.h:40:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/list:1351:5: error: too many
      template arguments for class template 'auto_ptr'
    unique_ptr<__node, _Dp> __hold(__node_alloc_traits::allocate(__na, 1), _Dp(__na, 1));
    ^                  ~~~~
parser/mpCompat.h:50:22: note: expanded from macro 'unique_ptr'
  #define unique_ptr auto_ptr
                     ^
```
without -std=c++11 in makefile when using Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn).