### PR TITLE
Remove unused field in mpICallback.h

### DIFF
--- a/parser/mpICallback.h
+++ b/parser/mpICallback.h
@@ -79,7 +79,6 @@ MUP_NAMESPACE_START
 
   private:
       parent_type *m_pParent;      ///< Pointer to the parser object using this callback
-      const IPackage *m_pPackage;  ///< Pointer to the package this callback is belonging to (may be zero)
       int  m_nArgc;                ///< Number of this function can take Arguments.
       int  m_nArgsPresent;         ///< Number of arguments actually submitted
   }; // class ICallback


### PR DESCRIPTION
When compiling mupx I get:
```
In file included from parser/mpICallback.cpp:39:
parser/mpICallback.h:82:23: warning: private field 'm_pPackage' is not used [-Wunused-private-field]
      const IPackage *m_pPackage;  ///< Pointer to the package this callback is belonging to (may be zero)
                      ^
1 warning generated.
```