### PR TITLE
COMP: compilation error due to BOM marker

### DIFF
--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -1,5 +1,4 @@
-﻿#include "mpParserMessageProvider.h"
-
+#include "mpParserMessageProvider.h"
 #include <cassert>
 #include "mpError.h"
 
@@ -111,7 +110,7 @@ MUP_NAMESPACE_START
 
   //-------------------------------------------------------------------------------------------------
   //
-  // class ParserMessageProviderGerman - German translations of Parser Messages 
+  // class ParserMessageProviderGerman - German translations of Parser Messages
   //
   //-------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
muparserx is used in OTB image processing library and compile from source in the Superbuild.

With a RedHat 5.10 and gcc 4.1.2, one user encounters a compilation error due to BOM marker into a file from MuParserX.

A file command on the file provide the following status:
mpParserMessageProvider.cpp: UTF-8 Unicode (with BOM) C program text, with CRLF line terminators
After remove the BOM marker, the same command provides:
mpParserMessageProvider.cpp: UTF-8 Unicode C program text, with CRLF line terminators

Without the BOM marker gcc build the file. No other file provide this BOM marker.

This bug was reported in OTB Mantis bug tracker:

https://bugs.orfeo-toolbox.org/view.php?id=1048