### PR TITLE
Added virtual destructor to IPrecedence base class

### DIFF
--- a/parser/mpIPrecedence.h
+++ b/parser/mpIPrecedence.h
@@ -51,6 +51,7 @@ MUP_NAMESPACE_START
   class IPrecedence
   {
   public:
+    virtual ~IPrecedence(){}
     virtual int GetPri() const = 0;
     virtual EOprtAsct GetAssociativity() const = 0;
   };


### PR DESCRIPTION
This fixes a warning when building with -Wnon-virtual-dtor
Since IPrecedence is an interface class with virtual methods