### PR TITLE
Fixed msvc compile for example code

### DIFF
--- a/sample/timer.cpp
+++ b/sample/timer.cpp
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#if defined(__WIN32__) || defined(WIN32)
+#if defined(__WIN32__) || defined(_WIN32)
 #include <Windows.h>
 DWORD tvs, tve;
 #else
@@ -14,7 +14,7 @@ struct timeval	tvs, tve;
 
 void StartTimer(void)
 {
-#if defined(__WIN32__) || defined(WIN32)
+#if defined(__WIN32__) || defined(_WIN32)
   tvs = GetTickCount();
 #else
   if (gettimeofday(&tvs,0)) fprintf(stderr,"cant get time!\n");
@@ -23,7 +23,7 @@ void StartTimer(void)
 
 double StopTimer(void)
 {
-#if defined(__WIN32__) || defined(WIN32)
+#if defined(__WIN32__) || defined(_WIN32)
   tve = GetTickCount();
   return tve - tvs;
 #else
@@ -36,7 +36,7 @@ double PrintTimer(void)
 {
   double t;
 
-#if defined(__WIN32__) || defined(WIN32)
+#if defined(__WIN32__) || defined(_WIN32)
   tve = GetTickCount();
   t = (double)(tve - tvs) / 1000.0;
   printf("%.3f ",t);


### PR DESCRIPTION
The ifdefs in timer.cpp were not working for msvc 2015 64 bit, so I changed the define to match example.cpp which uses _WIN32

I usually disable the example, but I thought it would be nice to fix it upstream. The ifdefs are just changed to match the other code so it shouldn’t be a big deal for anyone that was already compiling.

Just a thought, but let me know if you would like to see timer.cpp written around std::chrono without the ifdefs, since we do rely on c++11 anyone, that shouldn’t be a problem from a dependency standpoint.