### PR TITLE
Fix warnings gcc/clang

### DIFF
--- a/parser/mpOprtIndex.h
+++ b/parser/mpOprtIndex.h
@@ -56,7 +56,7 @@ MUP_NAMESPACE_START
   public:
     OprtIndex();
     virtual void Eval(ptr_val_type& ret, const ptr_val_type *arg, int argc) override;
-    virtual const char_type* GetDesc() const;
+    virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
   }; 
 

--- a/parser/mpOprtMatrix.h
+++ b/parser/mpOprtMatrix.h
@@ -62,7 +62,7 @@ MUP_NAMESPACE_START
   public:
       OprtCreateArray();
 	  virtual void Eval(ptr_val_type& ret, const ptr_val_type *arg, int argc) override;
-	  virtual const char_type* GetDesc() const;
+	  virtual const char_type* GetDesc() const override;
 	  virtual IToken* Clone() const override;
   };
 

--- a/parser/mpOprtPostfixCommon.h
+++ b/parser/mpOprtPostfixCommon.h
@@ -27,7 +27,7 @@ MUP_NAMESPACE_START
 
     OprtFact();
 
-    virtual void Eval(ptr_val_type& ret, const ptr_val_type *arg, int);
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *arg, int) override;
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
   };

--- a/parser/mpTest.cpp
+++ b/parser/mpTest.cpp
@@ -1641,7 +1641,7 @@ int ParserTester::EqnTest(const string_type &a_str, Value a_val, bool a_fPass, i
 			std::size_t n2 = p2.GetExprVar().size();
 			std::size_t n3 = p3.GetExprVar().size();
 
-			if (n2 + n3 != 2 * n2 || n2 != nExprVar)
+			if (n2 + n3 != 2 * n2 || int(n2) != nExprVar)
 			{
 				*m_stream << _T("  Number of expression variables is incorrect. (expected: ")
 					<< nExprVar << _T("; detected: ") << n2 << _T(")");

--- a/parser/mpTokenReader.cpp
+++ b/parser/mpTokenReader.cpp
@@ -279,8 +279,8 @@ void TokenReader::SkipCommentsAndWhitespaces()
 			// skip comments
 		case  '#':
 		{
-			int i = static_cast<int>(m_sExpr.find_first_of('\n', m_nPos + 1));
-			m_nPos = (i != string_type::npos) ? i : static_cast<int>(m_sExpr.length());
+			std::size_t i = m_sExpr.find_first_of('\n', m_nPos + 1);
+			m_nPos = static_cast<int>((i != string_type::npos) ? i : m_sExpr.length());
 		}
 		break;
 

--- a/parser/mpValue.h
+++ b/parser/mpValue.h
@@ -76,19 +76,19 @@ MUP_NAMESPACE_START
 
     virtual ~Value();
  
-    virtual IValue& At(int nRow, int nCol = 0);
-    virtual IValue& At(const IValue &row, const IValue &col);
+    virtual IValue& At(int nRow, int nCol = 0) override;
+    virtual IValue& At(const IValue &row, const IValue &col) override;
 
-    virtual IValue& operator=(int_type a_iVal);
-    virtual IValue& operator=(float_type a_fVal);
-    virtual IValue& operator=(string_type a_sVal);
-    virtual IValue& operator=(bool val);
-    virtual IValue& operator=(const matrix_type &a_vVal);
-    virtual IValue& operator=(const cmplx_type &val);
+    virtual IValue& operator=(int_type a_iVal) override;
+    virtual IValue& operator=(float_type a_fVal) override;
+    virtual IValue& operator=(string_type a_sVal) override;
+    virtual IValue& operator=(bool val) override;
+    virtual IValue& operator=(const matrix_type &a_vVal) override;
+    virtual IValue& operator=(const cmplx_type &val) override;
     virtual IValue& operator=(const char_type *a_szVal);
-    virtual IValue& operator+=(const IValue &val);
-    virtual IValue& operator-=(const IValue &val);
-    virtual IValue& operator*=(const IValue &val);
+    virtual IValue& operator+=(const IValue &val) override;
+    virtual IValue& operator-=(const IValue &val) override;
+    virtual IValue& operator*=(const IValue &val) override;
 
     virtual char_type GetType() const override;
     virtual int_type GetInteger() const override;
@@ -101,12 +101,12 @@ MUP_NAMESPACE_START
     virtual int GetRows() const override;
     virtual int GetCols() const override;
 
-    virtual bool IsVariable() const;
+    virtual bool IsVariable() const override;
 
-    virtual IToken* Clone() const;
+    virtual IToken* Clone() const override;
     virtual Value* AsValue() override;
 
-    virtual string_type AsciiDump() const;
+    virtual string_type AsciiDump() const override;
     void BindToCache(ValueCache *pCache);
 	
     // Conversion operators
@@ -129,7 +129,7 @@ MUP_NAMESPACE_START
     void Assign(const Value &a_Val);
     void Reset();
 
-    virtual void Release();
+    virtual void Release() override;
   }; // class Value
 
 


### PR DESCRIPTION
 **override keyword not applied consistently** 

* Adding override to these headers which already used override. Fixes warnings on osx high sierra.

 **fixed sign comparison warnings (gcc/clang)**

* mpTest.cpp - cast index to int when comparing
* mpTokenReader.cpp - keep string find result as a size_t for comparison to string npos, and then cast the entire expression to an int