### PR TITLE
Removed the use of std::binary_function. It was deprecated in C++11 a…

### DIFF
--- a/parser/suSortPred.h
+++ b/parser/suSortPred.h
@@ -32,7 +32,6 @@
   POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <functional>
 
 
 /** \brief Namespace containing utility functions and classes for string processing. */
@@ -44,7 +43,6 @@ namespace su
     */
     template<class TString>
 	  struct SortByLength
-      :public std::binary_function<TString, TString, bool>
 	  {	
 	    bool operator()(const TString& a_sLeft, const TString& a_sRight) const
       {	

--- a/value_test/suSortPred.h
+++ b/value_test/suSortPred.h
@@ -25,7 +25,6 @@
 #ifndef SU_PRED_H
 #define SU_PRED_H
 
-#include <functional>
 
 
 /** \brief Namespace containing utility functions and classes for string processing. */
@@ -37,7 +36,6 @@ namespace su
     */
     template<class TString>
 	  struct SortByLength
-      :public std::binary_function<TString, TString, bool>
 	  {	
 	    bool operator()(const TString& a_sLeft, const TString& a_sRight) const
 		  {	


### PR DESCRIPTION
…nd removed in C++17. It does not seem to have any purpose anymore anyway, as the SortByLength struct works as intended without it.
Ref. issue #94 