### PR TITLE
Add Github Action workflows for basic CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,31 @@
+name: build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CMAKE_BUILD_TYPE: Debug
+  CMAKE_BUILD_DIR: ${{ github.workspace }}/build
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-22.04, macOS-12]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build
+      shell: bash
+      run: |
+        mkdir -p $CMAKE_BUILD_DIR
+        cd  $CMAKE_BUILD_DIR
+        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ..
+        cmake --build .


### PR DESCRIPTION
Thanks for open sourcing `muparserx`. We are using it for parsing and evaluating expressions on the fly in [GenomicsDB](https://github.com/GenomicsDB/GenomicsDB) and this saved us time from writing something similar.

Just merged with the [latest commit](https://github.com/beltoforion/muparserx/commit/183fd91c9b92e4bb58a131e57ec4e21cff9a4363) from Dec 4, 2020 and this does not build on `MacOS` and `Ubuntu` as `sscanf_s` seems to be a Microsoft Visual Studio construct. See [build](https://github.com/nalinigans/muparserx/actions/runs/4257849608) for the failures. Some Linux C runtimes do support this - see https://en.cppreference.com/w/c/io/fscanf and even if supported it says we need to define `__STDC_WANT_LIB_EXT1__` before #include <stdio.h> which makes the usage hacky. There are similar issues in `sample/example.cpp` with `localtime_s` and `fopen_s`. 

We work primarily on Linux platforms, have the fixes - https://github.com/nalinigans/muparserx/pull/1 - for the issues above and are not blocked. Would you like another PR for the fixes? Thanks.