### PR TITLE
Github Action workflow changes to run examples (#2)

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -2,9 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
-    branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
 
 env:
   CMAKE_BUILD_TYPE: Debug
@@ -29,3 +31,18 @@ jobs:
         cd  $CMAKE_BUILD_DIR
         cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ..
         cmake --build .
+
+    - name: Test Examples
+      shell: bash
+      working-directory: ${{ env.CMAKE_BUILD_DIR }}
+      run: |
+        if [[ ${{ matrix.os }} == windows* ]]; then
+          EXAMPLE="$CMAKE_BUILD_TYPE/example.exe"
+        else
+          EXAMPLE="./example"
+        fi
+        $EXAMPLE &> example.log << EOF
+        quit
+        EOF
+        cat example.log
+        grep -e "Test passed.*expressions" example.log || (grep -e "Test failed.*expressions" example.log; exit 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,10 @@ set(MUPARSERX_VERSION ${CMAKE_MATCH_1})
 # Compiler specific flags
 ########################################################################
 if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    set(CMAKE_CXX_FLAGS_DEBUG "-D_DEBUG -g3 -gdwarf-3")
+    set(CMAKE_CXX_FLAGS_COVERAGE "-D_DEBUG -g3 -gdwarf-3 --coverage")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")    
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -39,6 +39,13 @@
 #include "mpValue.h"
 #include "mpError.h"
 
+#ifdef _MSC_VER
+#  define SSCANF sscanf_s
+#  define SWSCANF swscan_s
+#else
+#  define SSCANF sscanf
+#  define SWSCANF swscanf
+#endif
 
 MUP_NAMESPACE_START
 
@@ -158,9 +165,9 @@ MUP_NAMESPACE_START
     in = a_pArg[0]->GetString();
     
 #ifndef MUP_USE_WIDE_STRING    
-    sscanf_s(in.c_str(), "%lf", &out);
+    SSCANF(in.c_str(), "%lf", &out);
 #else
-    swscanf_s(in.c_str(), _T("%lf"), &out);
+    SWSCANF(in.c_str(), _T("%lf"), &out);
 #endif
 
     *ret = (float_type)out;

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -225,9 +225,15 @@ public:
 		time_t t = time(nullptr);
 		struct tm newtime;
 
+#ifdef _MSC_VER
 		errno_t err = localtime_s(&newtime, &t);
 		if (err != 0)
 			return;
+#else
+		auto* r = localtime_r(&t, &newtime);
+		if (!r)
+			return;
+#endif
 
 #ifdef _DEBUG
 		strftime(outstr, sizeof(outstr), "Result_%Y%m%d_%H%M%S_dbg.txt", &newtime);
@@ -289,9 +295,15 @@ public:
 		parser.DefineConst(_T("e"), (float_type)M_E);
 
 		FILE* pFile;
+#ifdef _MSC_VER
 		err = fopen_s(&pFile, outstr, "w");
 		if (err != 0)
 			return;
+#else
+		pFile = fopen(outstr, "w");
+		if (!pFile)
+			return;
+#endif
 
 		int iCount = 400000;
 


### PR DESCRIPTION
* Fixes for sscanf_s/localtime_s/fopen_s issues
Workaround for mainly Microsoft Visual Studio C API. Some Linux C runtimes do support this - see https://en.cppreference.com/w/c/io/fscanf and even if supported it says we need to define STDC_WANT_LIB_EXT1 before #include <stdio.h> which makes the usage hacky.
* Run CI on all branches for push and PRs
* Get examples running in Github Actions for a sanity check.
* Pass _Debug flags for gcc/clang compilers for Debug builds

Note: The [builds](https://github.com/beltoforion/muparserx/actions/runs/4298330589) pass for Windows/Linux, but fail on MacOS because of Issue #116.  Not sure if using `regex` is OK, but please see https://github.com/nalinigans/muparserx/blob/46d69f91cc15a3b3d52556d560a348ce79721117/parser/mpValReader.cpp#L70 for a possible fix to Issue #116.